### PR TITLE
allow <script> to support "src" attribute and load the referred content

### DIFF
--- a/packages/mina-loader/lib/loaders/mina.js
+++ b/packages/mina-loader/lib/loaders/mina.js
@@ -68,9 +68,19 @@ module.exports = function (source) {
       let parts = this.exec(source, parsedUrl)
 
       // compute output
-      let output = parts.script && parts.script.content ?
-        TYPES_FOR_OUTPUT.map((type) => `require(${loaderUtils.stringifyRequest(this, `!!${getLoaderOf(type, options)}${selectorLoaderPath}?type=script!${url}`)})`).join(';') :
-        ''
+      let output = '';
+
+      if (parts.script) {
+        let loadedContent;
+        if (parts.script.attributes.src) {
+          // content is defined in a separate file
+          loadedContent = parts.script.attributes.src
+        } else {
+          // content is defined inline
+          loadedContent = `${selectorLoaderPath}?type=script!${url}`
+        }
+        output = TYPES_FOR_OUTPUT.map((type) => `require(${loaderUtils.stringifyRequest(this, `!!${getLoaderOf(type, options)}${loadedContent}`)})`).join(';');
+      }
 
       return Promise
         // emit files


### PR DESCRIPTION
## Problem

I found that i cannot use typescript because once mina-webpack configures to use `ts-loader` instead of `babel-loader` to process TypeScript files, the TypeScript compiler will complain because `.mina` extension is not supported. There's no easy way to hack around the complier (there's an internal flag to turn the check off but it's hidden inside).

## Solution

A possible solution is to support `<script src="./app.ts">` syntax, allowing the content of script to be defined in a separate file.