### PR TITLE
入口适配插件

### DIFF
--- a/packages/mina-entry-webpack-plugin/index.js
+++ b/packages/mina-entry-webpack-plugin/index.js
@@ -38,14 +38,14 @@ function getUrlsFromConfig(config) {
   if (Array.isArray(config.pages)) {
     urls = [...urls, ...config.pages]
   }
-  if (typeof config.usingComponents === 'object') {
-    urls = [
-      ...urls,
-      ...Object.keys(config.usingComponents).map(
-        tag => config.usingComponents[tag]
-      ),
-    ]
-  }
+
+  ;['pages', 'usingComponents', 'publicComponents'].forEach(prop => {
+    if (typeof config[prop] !== 'object') {
+      return
+    }
+
+    urls = [...urls, ...Object.keys(config[prop]).map(tag => config[prop][tag])]
+  })
   return urls
 }
 


### PR DESCRIPTION
适配插件 `pages` 为对象，且增加 `publicComponents` 入口配置的读取。