### PR TITLE
[fix] remove main entry property

### DIFF
--- a/packages/mina-entry-webpack-plugin/index.js
+++ b/packages/mina-entry-webpack-plugin/index.js
@@ -39,10 +39,6 @@ function getUrlsFromConfig(config) {
     urls = [...urls, ...config.pages]
   }
 
-  if (config.main) {
-    urls = [...urls, config.main]
-  }
-
   ;['pages', 'usingComponents', 'publicComponents'].forEach(prop => {
     if (typeof config[prop] !== 'object') {
       return


### PR DESCRIPTION
main property entry in plugin is difference with normal mina app, it should have some exports like node.js module. So we remove auto detect entry in `mina-entry-webpack-plugin` and add entry in webpack config alone to config it freely.