### PR TITLE
在引入错误的组件的时候`npm start`不要退出

### DIFF
--- a/packages/mina-entry-webpack-plugin/lib/index.js
+++ b/packages/mina-entry-webpack-plugin/lib/index.js
@@ -76,18 +76,28 @@ function getItems(rootContext, entry, rules) {
 
     let resourcePath, isClassical
     try {
-      resourcePath = resolve.sync(request, {
-        basedir: rootContext,
-        extensions: [],
-      })
-      isClassical = false
+      try {
+        resourcePath = resolve.sync(request, {
+          basedir: rootContext,
+          extensions: [],
+        })
+        isClassical = false
+      } catch (error) {
+        resourcePath = resolve.sync(request, {
+          basedir: rootContext,
+          extensions: RESOLVE_EXTENSIONS,
+        })
+        request = `!${minaLoader}!${virtualMinaLoader}!${resourcePath}`
+        isClassical = true
+      }
     } catch (error) {
-      resourcePath = resolve.sync(request, {
-        basedir: rootContext,
-        extensions: RESOLVE_EXTENSIONS,
+      // Do not throw an exception when the module does not exist.
+      // Just mark it up and move on to the next module.
+      memory.push({
+        name: '<ERROR:NOT_FOUND>',
+        request: request,
       })
-      request = `!${minaLoader}!${virtualMinaLoader}!${resourcePath}`
-      isClassical = true
+      return
     }
 
     resourcePath = fs.realpathSync(resourcePath)

--- a/packages/mina-entry-webpack-plugin/package-lock.json
+++ b/packages/mina-entry-webpack-plugin/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinajs/mina-entry-webpack-plugin",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11,6 +11,69 @@
       "dev": true,
       "requires": {
         "any-observable": "^0.3.0"
+      }
+    },
+    "@tinajs/mina-loader": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/@tinajs/mina-loader/download/@tinajs/mina-loader-1.1.0.tgz",
+      "integrity": "sha1-hw/vBJNers86Q+XbJ1aDPg9XlQo=",
+      "dev": true,
+      "requires": {
+        "@tinajs/mina-sfc": "^0.2.0",
+        "@tinajs/wxml-loader": "0.3.1-fork.1",
+        "compose-function": "^3.0.3",
+        "css-loader": "^0.28.7",
+        "debug": "^3.1.0",
+        "ensure-posix-path": "^1.0.2",
+        "extract-loader": "^2.0.1",
+        "file-loader": "^1.1.11",
+        "json5": "^0.5.1",
+        "loader-utils": "^1.1.0",
+        "lodash.merge": "^4.6.0",
+        "object-path": "^0.11.4",
+        "p-all": "^1.0.0",
+        "p-map": "^1.2.0",
+        "postcss-url": "^8.0.0",
+        "replace-ext": "^1.0.0",
+        "resolve": "^1.8.1",
+        "style-loader": "^0.19.0",
+        "vue-template-compiler": "^2.5.3",
+        "wxml-loader": "^0.2.1"
+      }
+    },
+    "@tinajs/mina-sfc": {
+      "version": "0.2.2",
+      "resolved": "http://registry.npm.taobao.org/@tinajs/mina-sfc/download/@tinajs/mina-sfc-0.2.2.tgz",
+      "integrity": "sha1-kNpBXpJofpKghG4gur8D748v1zo=",
+      "dev": true,
+      "requires": {
+        "lodash.findlast": "^4.6.0",
+        "posthtml-parser": "^0.2.1",
+        "posthtml-render": "^1.0.6",
+        "vue-template-compiler": "^2.5.6"
+      },
+      "dependencies": {
+        "vue-template-compiler": {
+          "version": "2.5.17",
+          "resolved": "http://registry.npm.taobao.org/vue-template-compiler/download/vue-template-compiler-2.5.17.tgz",
+          "integrity": "sha1-UqSgeMMn3rk3SCpQmuhcBvNGw8s=",
+          "dev": true,
+          "requires": {
+            "de-indent": "^1.0.2",
+            "he": "^1.1.0"
+          }
+        }
+      }
+    },
+    "@tinajs/wxml-loader": {
+      "version": "0.3.1-fork.1",
+      "resolved": "http://registry.npm.taobao.org/@tinajs/wxml-loader/download/@tinajs/wxml-loader-0.3.1-fork.1.tgz",
+      "integrity": "sha1-ljZumcOcS5XW7gNRB0zNGXgxL+w=",
+      "dev": true,
+      "requires": {
+        "html-minifier": "^3.5.6",
+        "loader-utils": "^1.1.0",
+        "sax": "^1.2.2"
       }
     },
     "@webassemblyjs/ast": {
@@ -239,6 +302,12 @@
       "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
       "dev": true
     },
+    "alphanum-sort": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/alphanum-sort/download/alphanum-sort-1.0.2.tgz",
+      "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
+      "dev": true
+    },
     "ansi-escapes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
@@ -380,6 +449,52 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
       "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
       "dev": true
+    },
+    "autoprefixer": {
+      "version": "6.7.7",
+      "resolved": "http://registry.npm.taobao.org/autoprefixer/download/autoprefixer-6.7.7.tgz",
+      "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^1.7.6",
+        "caniuse-db": "^1.0.30000634",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^5.2.16",
+        "postcss-value-parser": "^3.2.3"
+      }
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "http://registry.npm.taobao.org/babel-code-frame/download/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "http://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        }
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -597,6 +712,16 @@
         "pako": "~1.0.5"
       }
     },
+    "browserslist": {
+      "version": "1.7.7",
+      "resolved": "http://registry.npm.taobao.org/browserslist/download/browserslist-1.7.7.tgz",
+      "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+      "dev": true,
+      "requires": {
+        "caniuse-db": "^1.0.30000639",
+        "electron-to-chromium": "^1.2.7"
+      }
+    },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
@@ -672,6 +797,34 @@
         }
       }
     },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.taobao.org/camel-case/download/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
+    "caniuse-api": {
+      "version": "1.6.1",
+      "resolved": "http://registry.npm.taobao.org/caniuse-api/download/caniuse-api-1.6.1.tgz",
+      "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^1.3.6",
+        "caniuse-db": "^1.0.30000529",
+        "lodash.memoize": "^4.1.2",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "caniuse-db": {
+      "version": "1.0.30000910",
+      "resolved": "http://registry.npm.taobao.org/caniuse-db/download/caniuse-db-1.0.30000910.tgz",
+      "integrity": "sha1-WMyoR4AiMpHCjpLZepsVEiYKmo4=",
+      "dev": true
+    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -746,6 +899,36 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "clap": {
+      "version": "1.2.3",
+      "resolved": "http://registry.npm.taobao.org/clap/download/clap-1.2.3.tgz",
+      "integrity": "sha1-TzZ0WzIAhJJVf0ZBLWbVDLmbzlE=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "http://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        }
+      }
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -771,6 +954,23 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "clean-css": {
+      "version": "4.2.1",
+      "resolved": "http://registry.npm.taobao.org/clean-css/download/clean-css-4.2.1.tgz",
+      "integrity": "sha1-LUEe92uFabbQyEBo2r6FsKpeXBc=",
+      "dev": true,
+      "requires": {
+        "source-map": "~0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -813,6 +1013,27 @@
         }
       }
     },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "http://registry.npm.taobao.org/clone/download/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "http://registry.npm.taobao.org/co/download/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "coa": {
+      "version": "1.0.4",
+      "resolved": "http://registry.npm.taobao.org/coa/download/coa-1.0.4.tgz",
+      "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
+      "dev": true,
+      "requires": {
+        "q": "^1.1.2"
+      }
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -829,6 +1050,17 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "0.11.4",
+      "resolved": "http://registry.npm.taobao.org/color/download/color-0.11.4.tgz",
+      "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2",
+        "color-convert": "^1.3.0",
+        "color-string": "^0.3.0"
+      }
+    },
     "color-convert": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
@@ -842,6 +1074,32 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
+      "dev": true
+    },
+    "color-string": {
+      "version": "0.3.0",
+      "resolved": "http://registry.npm.taobao.org/color-string/download/color-string-0.3.0.tgz",
+      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.0.0"
+      }
+    },
+    "colormin": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/colormin/download/colormin-1.1.2.tgz",
+      "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
+      "dev": true,
+      "requires": {
+        "color": "^0.11.0",
+        "css-color-names": "0.0.4",
+        "has": "^1.0.1"
+      }
+    },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/colors/download/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
     },
     "commander": {
@@ -1018,6 +1276,107 @@
         "randomfill": "^1.0.3"
       }
     },
+    "css-color-names": {
+      "version": "0.0.4",
+      "resolved": "http://registry.npm.taobao.org/css-color-names/download/css-color-names-0.0.4.tgz",
+      "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
+      "dev": true
+    },
+    "css-loader": {
+      "version": "0.28.11",
+      "resolved": "http://registry.npm.taobao.org/css-loader/download/css-loader-0.28.11.tgz",
+      "integrity": "sha1-w/mGSnAL4nEbtaJGKyOJsaOS2rc=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "css-selector-tokenizer": "^0.7.0",
+        "cssnano": "^3.10.0",
+        "icss-utils": "^2.1.0",
+        "loader-utils": "^1.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "object-assign": "^4.1.1",
+        "postcss": "^5.0.6",
+        "postcss-modules-extract-imports": "^1.2.0",
+        "postcss-modules-local-by-default": "^1.2.0",
+        "postcss-modules-scope": "^1.1.0",
+        "postcss-modules-values": "^1.3.0",
+        "postcss-value-parser": "^3.3.0",
+        "source-list-map": "^2.0.0"
+      }
+    },
+    "css-selector-tokenizer": {
+      "version": "0.7.1",
+      "resolved": "http://registry.npm.taobao.org/css-selector-tokenizer/download/css-selector-tokenizer-0.7.1.tgz",
+      "integrity": "sha1-oXcnGovKUBkXL0+JH8bu2cv2jV0=",
+      "dev": true,
+      "requires": {
+        "cssesc": "^0.1.0",
+        "fastparse": "^1.1.1",
+        "regexpu-core": "^1.0.0"
+      }
+    },
+    "cssesc": {
+      "version": "0.1.0",
+      "resolved": "http://registry.npm.taobao.org/cssesc/download/cssesc-0.1.0.tgz",
+      "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+      "dev": true
+    },
+    "cssnano": {
+      "version": "3.10.0",
+      "resolved": "http://registry.npm.taobao.org/cssnano/download/cssnano-3.10.0.tgz",
+      "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
+      "dev": true,
+      "requires": {
+        "autoprefixer": "^6.3.1",
+        "decamelize": "^1.1.2",
+        "defined": "^1.0.0",
+        "has": "^1.0.1",
+        "object-assign": "^4.0.1",
+        "postcss": "^5.0.14",
+        "postcss-calc": "^5.2.0",
+        "postcss-colormin": "^2.1.8",
+        "postcss-convert-values": "^2.3.4",
+        "postcss-discard-comments": "^2.0.4",
+        "postcss-discard-duplicates": "^2.0.1",
+        "postcss-discard-empty": "^2.0.1",
+        "postcss-discard-overridden": "^0.1.1",
+        "postcss-discard-unused": "^2.2.1",
+        "postcss-filter-plugins": "^2.0.0",
+        "postcss-merge-idents": "^2.1.5",
+        "postcss-merge-longhand": "^2.0.1",
+        "postcss-merge-rules": "^2.0.3",
+        "postcss-minify-font-values": "^1.0.2",
+        "postcss-minify-gradients": "^1.0.1",
+        "postcss-minify-params": "^1.0.4",
+        "postcss-minify-selectors": "^2.0.4",
+        "postcss-normalize-charset": "^1.1.0",
+        "postcss-normalize-url": "^3.0.7",
+        "postcss-ordered-values": "^2.1.0",
+        "postcss-reduce-idents": "^2.2.2",
+        "postcss-reduce-initial": "^1.0.0",
+        "postcss-reduce-transforms": "^1.0.3",
+        "postcss-svgo": "^2.1.1",
+        "postcss-unique-selectors": "^2.0.2",
+        "postcss-value-parser": "^3.2.3",
+        "postcss-zindex": "^2.0.1"
+      }
+    },
+    "csso": {
+      "version": "2.3.2",
+      "resolved": "http://registry.npm.taobao.org/csso/download/csso-2.3.2.tgz",
+      "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
+      "dev": true,
+      "requires": {
+        "clap": "^1.0.9",
+        "source-map": "^0.5.3"
+      }
+    },
+    "cuint": {
+      "version": "0.2.2",
+      "resolved": "http://registry.npm.taobao.org/cuint/download/cuint-0.2.2.tgz",
+      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
+      "dev": true
+    },
     "cyclist": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
@@ -1049,6 +1408,12 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/decamelize/download/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -1115,6 +1480,12 @@
         }
       }
     },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/defined/download/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
     "des.js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
@@ -1136,11 +1507,54 @@
         "randombytes": "^2.0.0"
       }
     },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "http://registry.npm.taobao.org/dom-serializer/download/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npm.taobao.org/domelementtype/download/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        }
+      }
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "http://registry.npm.taobao.org/domelementtype/download/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "http://registry.npm.taobao.org/domhandler/download/domhandler-2.4.2.tgz",
+      "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "http://registry.npm.taobao.org/domutils/download/domutils-1.7.0.tgz",
+      "integrity": "sha1-Vuo0HoNOBuZ0ivehyyXaZ+qfjCo=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
     },
     "duplexify": {
       "version": "3.6.0",
@@ -1153,6 +1567,12 @@
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
       }
+    },
+    "electron-to-chromium": {
+      "version": "1.3.84",
+      "resolved": "http://registry.npm.taobao.org/electron-to-chromium/download/electron-to-chromium-1.3.84.tgz",
+      "integrity": "sha1-LlXfWegY8VCp9htTRx6/Tw/uzGU=",
+      "dev": true
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -1204,6 +1624,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz",
       "integrity": "sha1-pls+QtC3HPxYXrd0+ZQ8jZuRsMI="
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/entities/download/entities-1.1.2.tgz",
+      "integrity": "sha1-vfpzUplmTfr9NFKe1PhSKidf6lY=",
+      "dev": true
     },
     "errno": {
       "version": "0.1.7",
@@ -1258,6 +1684,12 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "http://registry.npm.taobao.org/esutils/download/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
     "events": {
@@ -1418,6 +1850,15 @@
         }
       }
     },
+    "extract-loader": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npm.taobao.org/extract-loader/download/extract-loader-2.0.1.tgz",
+      "integrity": "sha1-PfpX1ZIsDtu2JISQGD/4YC58ySs=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0"
+      }
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -1430,6 +1871,12 @@
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
+    "fastparse": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/fastparse/download/fastparse-1.1.2.tgz",
+      "integrity": "sha1-kXKMWllC7O2FMSg8eUQe5BIsNak=",
+      "dev": true
+    },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -1438,6 +1885,16 @@
       "requires": {
         "escape-string-regexp": "^1.0.5",
         "object-assign": "^4.1.0"
+      }
+    },
+    "file-loader": {
+      "version": "1.1.11",
+      "resolved": "http://registry.npm.taobao.org/file-loader/download/file-loader-1.1.11.tgz",
+      "integrity": "sha1-b+iGRJsPKpNuQ8q6rAzb+zaVBvg=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.0.2",
+        "schema-utils": "^0.4.5"
       }
     },
     "fill-range": {
@@ -2086,6 +2543,12 @@
         }
       }
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npm.taobao.org/function-bind/download/function-bind-1.1.1.tgz",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+      "dev": true
+    },
     "get-own-enumerable-property-symbols": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
@@ -2144,6 +2607,15 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.taobao.org/has/download/has-1.0.3.tgz",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -2152,6 +2624,12 @@
       "requires": {
         "ansi-regex": "^2.0.0"
       }
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/has-flag/download/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -2249,11 +2727,122 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "html-comment-regex": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/html-comment-regex/download/html-comment-regex-1.1.2.tgz",
+      "integrity": "sha1-l9RoiutcgYhqNk+qDK0d2hTUM6c=",
+      "dev": true
+    },
+    "html-minifier": {
+      "version": "3.5.21",
+      "resolved": "http://registry.npm.taobao.org/html-minifier/download/html-minifier-3.5.21.tgz",
+      "integrity": "sha1-0AQOBUcw41TbAIRjWTGUAVIS0gw=",
+      "dev": true,
+      "requires": {
+        "camel-case": "3.0.x",
+        "clean-css": "4.2.x",
+        "commander": "2.17.x",
+        "he": "1.2.x",
+        "param-case": "2.1.x",
+        "relateurl": "0.2.x",
+        "uglify-js": "3.4.x"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "http://registry.npm.taobao.org/commander/download/commander-2.17.1.tgz",
+          "integrity": "sha1-vXerfebelCBc6sxy8XFtKfIKd78=",
+          "dev": true
+        },
+        "he": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npm.taobao.org/he/download/he-1.2.0.tgz",
+          "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
+          "dev": true
+        }
+      }
+    },
+    "htmlparser2": {
+      "version": "3.10.0",
+      "resolved": "http://registry.npm.taobao.org/htmlparser2/download/htmlparser2-3.10.0.tgz",
+      "integrity": "sha1-X15CLc9hGcDZg+02Jgzp3tC+5GQ=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.0.6",
+          "resolved": "http://registry.npm.taobao.org/readable-stream/download/readable-stream-3.0.6.tgz",
+          "integrity": "sha1-NRMC5MaLWr1qLtVTdqf5olvjBXo=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
+    },
+    "icss-replace-symbols": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/icss-replace-symbols/download/icss-replace-symbols-1.1.0.tgz",
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+      "dev": true
+    },
+    "icss-utils": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.taobao.org/icss-utils/download/icss-utils-2.1.0.tgz",
+      "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+      "dev": true,
+      "requires": {
+        "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/has-flag/download/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-6.0.23.tgz",
+          "integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
     },
     "ieee754": {
       "version": "1.1.12",
@@ -2282,6 +2871,12 @@
         "repeating": "^2.0.0"
       }
     },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/indexes-of/download/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
+    },
     "indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
@@ -2302,6 +2897,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-absolute-url": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.taobao.org/is-absolute-url/download/is-absolute-url-2.1.0.tgz",
+      "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
       "dev": true
     },
     "is-accessor-descriptor": {
@@ -2431,6 +3032,12 @@
         "symbol-observable": "^1.1.0"
       }
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/is-plain-obj/download/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -2465,6 +3072,15 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
+    },
+    "is-svg": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.taobao.org/is-svg/download/is-svg-2.1.0.tgz",
+      "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
+      "dev": true,
+      "requires": {
+        "html-comment-regex": "^1.1.0"
+      }
     },
     "is-windows": {
       "version": "1.0.2",
@@ -2508,6 +3124,18 @@
         "pretty-format": "^23.2.0"
       }
     },
+    "js-base64": {
+      "version": "2.4.9",
+      "resolved": "http://registry.npm.taobao.org/js-base64/download/js-base64-2.4.9.tgz",
+      "integrity": "sha1-dIkR+wT0imDEdxs3XKxFqA3xHAM=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "http://registry.npm.taobao.org/js-tokens/download/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
     "js-yaml": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
@@ -2517,6 +3145,12 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
+    },
+    "jsesc": {
+      "version": "0.5.0",
+      "resolved": "http://registry.npm.taobao.org/jsesc/download/jsesc-0.5.0.tgz",
+      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+      "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -3105,10 +3739,40 @@
         "path-exists": "^3.0.0"
       }
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "http://registry.npm.taobao.org/lodash.camelcase/download/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
+    "lodash.findlast": {
+      "version": "4.6.0",
+      "resolved": "http://registry.npm.taobao.org/lodash.findlast/download/lodash.findlast-4.6.0.tgz",
+      "integrity": "sha1-6ou3jPLn54BPyK630ZU+B/4x+8g=",
+      "dev": true
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "http://registry.npm.taobao.org/lodash.memoize/download/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "http://registry.npm.taobao.org/lodash.merge/download/lodash.merge-4.6.1.tgz",
+      "integrity": "sha1-rcJdnLmbk5HFliTzefu6YNcRHVQ=",
+      "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "http://registry.npm.taobao.org/lodash.uniq/download/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
     "log-symbols": {
@@ -3134,6 +3798,12 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
       "integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s=",
+      "dev": true
+    },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "http://registry.npm.taobao.org/lower-case/download/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
       "dev": true
     },
     "lru-cache": {
@@ -3175,6 +3845,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "math-expression-evaluator": {
+      "version": "1.2.17",
+      "resolved": "http://registry.npm.taobao.org/math-expression-evaluator/download/math-expression-evaluator-1.2.17.tgz",
+      "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.4",
@@ -3234,6 +3910,12 @@
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
       }
+    },
+    "mime": {
+      "version": "2.3.1",
+      "resolved": "http://registry.npm.taobao.org/mime/download/mime-2.3.1.tgz",
+      "integrity": "sha1-sWIcVNY7l8R9PP5/chX31kUXw2k=",
+      "dev": true
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -3381,6 +4063,15 @@
       "integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA==",
       "dev": true
     },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "http://registry.npm.taobao.org/no-case/download/no-case-2.3.2.tgz",
+      "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
+    },
     "node-libs-browser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
@@ -3429,6 +4120,24 @@
         "remove-trailing-separator": "^1.0.1"
       }
     },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "http://registry.npm.taobao.org/normalize-range/download/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true
+    },
+    "normalize-url": {
+      "version": "1.9.1",
+      "resolved": "http://registry.npm.taobao.org/normalize-url/download/normalize-url-1.9.1.tgz",
+      "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.0.1",
+        "prepend-http": "^1.0.0",
+        "query-string": "^4.1.0",
+        "sort-keys": "^1.0.0"
+      }
+    },
     "npm-path": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
@@ -3457,6 +4166,12 @@
         "npm-path": "^2.0.2",
         "which": "^1.2.10"
       }
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "http://registry.npm.taobao.org/num2fraction/download/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+      "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -3491,6 +4206,12 @@
           }
         }
       }
+    },
+    "object-path": {
+      "version": "0.11.4",
+      "resolved": "http://registry.npm.taobao.org/object-path/download/object-path-0.11.4.tgz",
+      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -3586,6 +4307,15 @@
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
+    "p-all": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/p-all/download/p-all-1.0.0.tgz",
+      "integrity": "sha1-k731OlWiOCH9+pi0F0qZv38x340=",
+      "dev": true,
+      "requires": {
+        "p-map": "^1.0.0"
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -3644,6 +4374,15 @@
         "cyclist": "~0.2.2",
         "inherits": "^2.0.3",
         "readable-stream": "^2.1.5"
+      }
+    },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "http://registry.npm.taobao.org/param-case/download/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
       }
     },
     "parse-asn1": {
@@ -3749,6 +4488,594 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "postcss": {
+      "version": "5.2.18",
+      "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-5.2.18.tgz",
+      "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "js-base64": "^2.1.9",
+        "source-map": "^0.5.6",
+        "supports-color": "^3.2.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "http://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
+      }
+    },
+    "postcss-calc": {
+      "version": "5.3.1",
+      "resolved": "http://registry.npm.taobao.org/postcss-calc/download/postcss-calc-5.3.1.tgz",
+      "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.2",
+        "postcss-message-helpers": "^2.0.0",
+        "reduce-css-calc": "^1.2.6"
+      }
+    },
+    "postcss-colormin": {
+      "version": "2.2.2",
+      "resolved": "http://registry.npm.taobao.org/postcss-colormin/download/postcss-colormin-2.2.2.tgz",
+      "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
+      "dev": true,
+      "requires": {
+        "colormin": "^1.0.5",
+        "postcss": "^5.0.13",
+        "postcss-value-parser": "^3.2.3"
+      }
+    },
+    "postcss-convert-values": {
+      "version": "2.6.1",
+      "resolved": "http://registry.npm.taobao.org/postcss-convert-values/download/postcss-convert-values-2.6.1.tgz",
+      "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.11",
+        "postcss-value-parser": "^3.1.2"
+      }
+    },
+    "postcss-discard-comments": {
+      "version": "2.0.4",
+      "resolved": "http://registry.npm.taobao.org/postcss-discard-comments/download/postcss-discard-comments-2.0.4.tgz",
+      "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.14"
+      }
+    },
+    "postcss-discard-duplicates": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.taobao.org/postcss-discard-duplicates/download/postcss-discard-duplicates-2.1.0.tgz",
+      "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.4"
+      }
+    },
+    "postcss-discard-empty": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.taobao.org/postcss-discard-empty/download/postcss-discard-empty-2.1.0.tgz",
+      "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.14"
+      }
+    },
+    "postcss-discard-overridden": {
+      "version": "0.1.1",
+      "resolved": "http://registry.npm.taobao.org/postcss-discard-overridden/download/postcss-discard-overridden-0.1.1.tgz",
+      "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.16"
+      }
+    },
+    "postcss-discard-unused": {
+      "version": "2.2.3",
+      "resolved": "http://registry.npm.taobao.org/postcss-discard-unused/download/postcss-discard-unused-2.2.3.tgz",
+      "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.14",
+        "uniqs": "^2.0.0"
+      }
+    },
+    "postcss-filter-plugins": {
+      "version": "2.0.3",
+      "resolved": "http://registry.npm.taobao.org/postcss-filter-plugins/download/postcss-filter-plugins-2.0.3.tgz",
+      "integrity": "sha1-giRf34IzcEFkXkdxFNjlk6oYuOw=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.4"
+      }
+    },
+    "postcss-merge-idents": {
+      "version": "2.1.7",
+      "resolved": "http://registry.npm.taobao.org/postcss-merge-idents/download/postcss-merge-idents-2.1.7.tgz",
+      "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1",
+        "postcss": "^5.0.10",
+        "postcss-value-parser": "^3.1.1"
+      }
+    },
+    "postcss-merge-longhand": {
+      "version": "2.0.2",
+      "resolved": "http://registry.npm.taobao.org/postcss-merge-longhand/download/postcss-merge-longhand-2.0.2.tgz",
+      "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.4"
+      }
+    },
+    "postcss-merge-rules": {
+      "version": "2.1.2",
+      "resolved": "http://registry.npm.taobao.org/postcss-merge-rules/download/postcss-merge-rules-2.1.2.tgz",
+      "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^1.5.2",
+        "caniuse-api": "^1.5.2",
+        "postcss": "^5.0.4",
+        "postcss-selector-parser": "^2.2.2",
+        "vendors": "^1.0.0"
+      }
+    },
+    "postcss-message-helpers": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/postcss-message-helpers/download/postcss-message-helpers-2.0.0.tgz",
+      "integrity": "sha1-pPL0+rbk/gAvCu0ABHjN9S+bpg4=",
+      "dev": true
+    },
+    "postcss-minify-font-values": {
+      "version": "1.0.5",
+      "resolved": "http://registry.npm.taobao.org/postcss-minify-font-values/download/postcss-minify-font-values-1.0.5.tgz",
+      "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.0.1",
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.2"
+      }
+    },
+    "postcss-minify-gradients": {
+      "version": "1.0.5",
+      "resolved": "http://registry.npm.taobao.org/postcss-minify-gradients/download/postcss-minify-gradients-1.0.5.tgz",
+      "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.12",
+        "postcss-value-parser": "^3.3.0"
+      }
+    },
+    "postcss-minify-params": {
+      "version": "1.2.2",
+      "resolved": "http://registry.npm.taobao.org/postcss-minify-params/download/postcss-minify-params-1.2.2.tgz",
+      "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "^1.0.1",
+        "postcss": "^5.0.2",
+        "postcss-value-parser": "^3.0.2",
+        "uniqs": "^2.0.0"
+      }
+    },
+    "postcss-minify-selectors": {
+      "version": "2.1.1",
+      "resolved": "http://registry.npm.taobao.org/postcss-minify-selectors/download/postcss-minify-selectors-2.1.1.tgz",
+      "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "^1.0.2",
+        "has": "^1.0.1",
+        "postcss": "^5.0.14",
+        "postcss-selector-parser": "^2.0.0"
+      }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "1.2.1",
+      "resolved": "http://registry.npm.taobao.org/postcss-modules-extract-imports/download/postcss-modules-extract-imports-1.2.1.tgz",
+      "integrity": "sha1-3IfjQUjsfqtfeR981YSYMzdbdBo=",
+      "dev": true,
+      "requires": {
+        "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/has-flag/download/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-6.0.23.tgz",
+          "integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-local-by-default": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/postcss-modules-local-by-default/download/postcss-modules-local-by-default-1.2.0.tgz",
+      "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+      "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/has-flag/download/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-6.0.23.tgz",
+          "integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/postcss-modules-scope/download/postcss-modules-scope-1.1.0.tgz",
+      "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+      "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/has-flag/download/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-6.0.23.tgz",
+          "integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-values": {
+      "version": "1.3.0",
+      "resolved": "http://registry.npm.taobao.org/postcss-modules-values/download/postcss-modules-values-1.3.0.tgz",
+      "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+      "dev": true,
+      "requires": {
+        "icss-replace-symbols": "^1.1.0",
+        "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/has-flag/download/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-6.0.23.tgz",
+          "integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-normalize-charset": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npm.taobao.org/postcss-normalize-charset/download/postcss-normalize-charset-1.1.1.tgz",
+      "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.5"
+      }
+    },
+    "postcss-normalize-url": {
+      "version": "3.0.8",
+      "resolved": "http://registry.npm.taobao.org/postcss-normalize-url/download/postcss-normalize-url-3.0.8.tgz",
+      "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
+      "dev": true,
+      "requires": {
+        "is-absolute-url": "^2.0.0",
+        "normalize-url": "^1.4.0",
+        "postcss": "^5.0.14",
+        "postcss-value-parser": "^3.2.3"
+      }
+    },
+    "postcss-ordered-values": {
+      "version": "2.2.3",
+      "resolved": "http://registry.npm.taobao.org/postcss-ordered-values/download/postcss-ordered-values-2.2.3.tgz",
+      "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.1"
+      }
+    },
+    "postcss-reduce-idents": {
+      "version": "2.4.0",
+      "resolved": "http://registry.npm.taobao.org/postcss-reduce-idents/download/postcss-reduce-idents-2.4.0.tgz",
+      "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.2"
+      }
+    },
+    "postcss-reduce-initial": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/postcss-reduce-initial/download/postcss-reduce-initial-1.0.1.tgz",
+      "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
+      "dev": true,
+      "requires": {
+        "postcss": "^5.0.4"
+      }
+    },
+    "postcss-reduce-transforms": {
+      "version": "1.0.4",
+      "resolved": "http://registry.npm.taobao.org/postcss-reduce-transforms/download/postcss-reduce-transforms-1.0.4.tgz",
+      "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1",
+        "postcss": "^5.0.8",
+        "postcss-value-parser": "^3.0.1"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "2.2.3",
+      "resolved": "http://registry.npm.taobao.org/postcss-selector-parser/download/postcss-selector-parser-2.2.3.tgz",
+      "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+      "dev": true,
+      "requires": {
+        "flatten": "^1.0.2",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      }
+    },
+    "postcss-svgo": {
+      "version": "2.1.6",
+      "resolved": "http://registry.npm.taobao.org/postcss-svgo/download/postcss-svgo-2.1.6.tgz",
+      "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
+      "dev": true,
+      "requires": {
+        "is-svg": "^2.0.0",
+        "postcss": "^5.0.14",
+        "postcss-value-parser": "^3.2.3",
+        "svgo": "^0.7.0"
+      }
+    },
+    "postcss-unique-selectors": {
+      "version": "2.0.2",
+      "resolved": "http://registry.npm.taobao.org/postcss-unique-selectors/download/postcss-unique-selectors-2.0.2.tgz",
+      "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "^1.0.1",
+        "postcss": "^5.0.4",
+        "uniqs": "^2.0.0"
+      }
+    },
+    "postcss-url": {
+      "version": "8.0.0",
+      "resolved": "http://registry.npm.taobao.org/postcss-url/download/postcss-url-8.0.0.tgz",
+      "integrity": "sha1-exAFm9EpKc27GXHGD2Gg5a+GtMo=",
+      "dev": true,
+      "requires": {
+        "mime": "^2.3.1",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.0",
+        "postcss": "^7.0.2",
+        "xxhashjs": "^0.2.1"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/has-flag/download/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.6",
+          "resolved": "http://registry.npm.taobao.org/postcss/download/postcss-7.0.6.tgz",
+          "integrity": "sha1-bcqh6ZnN1KJV3NfU2VR/TKAQzcI=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "http://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+      "dev": true
+    },
+    "postcss-zindex": {
+      "version": "2.2.0",
+      "resolved": "http://registry.npm.taobao.org/postcss-zindex/download/postcss-zindex-2.2.0.tgz",
+      "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1",
+        "postcss": "^5.0.4",
+        "uniqs": "^2.0.0"
+      }
+    },
+    "posthtml-parser": {
+      "version": "0.2.1",
+      "resolved": "http://registry.npm.taobao.org/posthtml-parser/download/posthtml-parser-0.2.1.tgz",
+      "integrity": "sha1-NdUw3jhnQMK6JP8usvrznM3ycd0=",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "^3.8.3",
+        "isobject": "^2.1.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "2.1.0",
+          "resolved": "http://registry.npm.taobao.org/isobject/download/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "dev": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        }
+      }
+    },
+    "posthtml-render": {
+      "version": "1.1.4",
+      "resolved": "http://registry.npm.taobao.org/posthtml-render/download/posthtml-render-1.1.4.tgz",
+      "integrity": "sha1-ldrAmJL08YP61ayCPwj0LAJWVR4=",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "http://registry.npm.taobao.org/prepend-http/download/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
     "prettier": {
       "version": "1.13.7",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.7.tgz",
@@ -3843,6 +5170,22 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "http://registry.npm.taobao.org/q/download/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
+    },
+    "query-string": {
+      "version": "4.3.4",
+      "resolved": "http://registry.npm.taobao.org/query-string/download/query-string-4.3.4.tgz",
+      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
+    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -3901,6 +5244,48 @@
         "set-immediate-shim": "^1.0.1"
       }
     },
+    "reduce-css-calc": {
+      "version": "1.3.0",
+      "resolved": "http://registry.npm.taobao.org/reduce-css-calc/download/reduce-css-calc-1.3.0.tgz",
+      "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^0.4.2",
+        "math-expression-evaluator": "^1.2.14",
+        "reduce-function-call": "^1.0.1"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "http://registry.npm.taobao.org/balanced-match/download/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "dev": true
+        }
+      }
+    },
+    "reduce-function-call": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/reduce-function-call/download/reduce-function-call-1.0.2.tgz",
+      "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^0.4.2"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "0.4.2",
+          "resolved": "http://registry.npm.taobao.org/balanced-match/download/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "dev": true
+        }
+      }
+    },
+    "regenerate": {
+      "version": "1.4.0",
+      "resolved": "http://registry.npm.taobao.org/regenerate/download/regenerate-1.4.0.tgz",
+      "integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE=",
+      "dev": true
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -3910,6 +5295,38 @@
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
       }
+    },
+    "regexpu-core": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/regexpu-core/download/regexpu-core-1.0.0.tgz",
+      "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
+      }
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "resolved": "http://registry.npm.taobao.org/regjsgen/download/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "resolved": "http://registry.npm.taobao.org/regjsparser/download/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      }
+    },
+    "relateurl": {
+      "version": "0.2.7",
+      "resolved": "http://registry.npm.taobao.org/relateurl/download/relateurl-0.2.7.tgz",
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+      "dev": true
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -4029,6 +5446,12 @@
       "requires": {
         "ret": "~0.1.10"
       }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "http://registry.npm.taobao.org/sax/download/sax-1.2.4.tgz",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+      "dev": true
     },
     "schema-utils": {
       "version": "0.4.5",
@@ -4241,6 +5664,15 @@
         "kind-of": "^3.2.0"
       }
     },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/sort-keys/download/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
+    },
     "source-list-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
@@ -4362,6 +5794,12 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/strict-uri-encode/download/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
+    },
     "string-argv": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
@@ -4402,6 +5840,90 @@
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
+    },
+    "style-loader": {
+      "version": "0.19.1",
+      "resolved": "http://registry.npm.taobao.org/style-loader/download/style-loader-0.19.1.tgz",
+      "integrity": "sha1-WR/8gLzv4mi3fF2evAUF13Jhn4U=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.0.2",
+        "schema-utils": "^0.3.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "http://registry.npm.taobao.org/ajv/download/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npm.taobao.org/fast-deep-equal/download/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "http://registry.npm.taobao.org/json-schema-traverse/download/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "0.3.0",
+          "resolved": "http://registry.npm.taobao.org/schema-utils/download/schema-utils-0.3.0.tgz",
+          "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
+          "dev": true,
+          "requires": {
+            "ajv": "^5.0.0"
+          }
+        }
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "svgo": {
+      "version": "0.7.2",
+      "resolved": "http://registry.npm.taobao.org/svgo/download/svgo-0.7.2.tgz",
+      "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
+      "dev": true,
+      "requires": {
+        "coa": "~1.0.1",
+        "colors": "~1.1.2",
+        "csso": "~2.3.1",
+        "js-yaml": "~3.7.0",
+        "mkdirp": "~0.5.1",
+        "sax": "~1.2.1",
+        "whet.extend": "~0.9.9"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "http://registry.npm.taobao.org/esprima/download/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.7.0",
+          "resolved": "http://registry.npm.taobao.org/js-yaml/download/js-yaml-3.7.0.tgz",
+          "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^2.6.0"
+          }
+        }
+      }
     },
     "symbol-observable": {
       "version": "1.2.0",
@@ -4524,6 +6046,30 @@
         }
       }
     },
+    "uglify-js": {
+      "version": "3.4.9",
+      "resolved": "http://registry.npm.taobao.org/uglify-js/download/uglify-js-3.4.9.tgz",
+      "integrity": "sha1-rwLxgMEgfXZDLkc+0koo9KeCuuM=",
+      "dev": true,
+      "requires": {
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "http://registry.npm.taobao.org/commander/download/commander-2.17.1.tgz",
+          "integrity": "sha1-vXerfebelCBc6sxy8XFtKfIKd78=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
     "uglifyjs-webpack-plugin": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.7.tgz",
@@ -4582,6 +6128,18 @@
           }
         }
       }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/uniq/download/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
+    "uniqs": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/uniqs/download/uniqs-2.0.0.tgz",
+      "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+      "dev": true
     },
     "unique-filename": {
       "version": "1.1.0",
@@ -4658,6 +6216,12 @@
       "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
       "dev": true
     },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "http://registry.npm.taobao.org/upper-case/download/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+      "dev": true
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -4721,6 +6285,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "vendors": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/vendors/download/vendors-1.0.2.tgz",
+      "integrity": "sha1-f8te759WI7FWvOqJ7DfWNnbyGAE=",
       "dev": true
     },
     "vm-browserify": {
@@ -4803,6 +6373,12 @@
         }
       }
     },
+    "whet.extend": {
+      "version": "0.9.9",
+      "resolved": "http://registry.npm.taobao.org/whet.extend/download/whet.extend-0.9.9.tgz",
+      "integrity": "sha1-+HfVv2SMl+WqVC+twW1qJZucEaE=",
+      "dev": true
+    },
     "which": {
       "version": "1.3.0",
       "resolved": "http://registry.npm.taobao.org/which/download/which-1.3.0.tgz",
@@ -4827,11 +6403,31 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
+    "wxml-loader": {
+      "version": "0.2.2",
+      "resolved": "http://registry.npm.taobao.org/wxml-loader/download/wxml-loader-0.2.2.tgz",
+      "integrity": "sha1-Uk5pBgO2NLRvzVM3szTgrs/OmKI=",
+      "dev": true,
+      "requires": {
+        "html-minifier": "^3.5.6",
+        "loader-utils": "^1.1.0",
+        "sax": "^1.2.2"
+      }
+    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
+    },
+    "xxhashjs": {
+      "version": "0.2.2",
+      "resolved": "http://registry.npm.taobao.org/xxhashjs/download/xxhashjs-0.2.2.tgz",
+      "integrity": "sha1-imJRVnYhocRqWuIE2gJJx/jKqdg=",
+      "dev": true,
+      "requires": {
+        "cuint": "^0.2.2"
+      }
     },
     "y18n": {
       "version": "4.0.0",

--- a/packages/mina-loader/lib/loaders/mina-json-file.js
+++ b/packages/mina-loader/lib/loaders/mina-json-file.js
@@ -65,6 +65,18 @@ function resolveFile(source, target, context, workdir = './') {
   )
 }
 
+function tryResolveFile() {
+  try {
+    return resolveFile(...arguments)
+  } catch (error) {
+    if (error.code === 'MODULE_NOT_FOUND') {
+      return target
+    } else {
+      throw error
+    }
+  }
+}
+
 function resolveFromModule(context, filename) {
   return path.relative(
     context,
@@ -119,7 +131,7 @@ module.exports = function(source) {
         : mapObject.bind(null, pages)
       return Object.assign(config, {
         pages: map(page =>
-          resolveFile(this.resourcePath, page, this.rootContext)
+          tryResolveFile(this.resourcePath, page, this.rootContext)
         ),
       })
     })
@@ -136,7 +148,7 @@ module.exports = function(source) {
         subPackages: subPackages.map(({ root, pages }) => ({
           root,
           pages: pages.map(page =>
-            resolveFile(
+            tryResolveFile(
               this.resourcePath,
               path.join(root, page),
               this.rootContext,
@@ -160,7 +172,7 @@ module.exports = function(source) {
             return file
           }
 
-          return resolveFile(this.resourcePath, file, this.rootContext)
+          return tryResolveFile(this.resourcePath, file, this.rootContext)
         }),
       })
     })
@@ -174,7 +186,7 @@ module.exports = function(source) {
 
       return Object.assign(config, {
         publicComponents: mapObject(config.publicComponents, file =>
-          resolveFile(this.resourcePath, file, this.rootContext)
+          tryResolveFile(this.resourcePath, file, this.rootContext)
         ),
       })
     })

--- a/packages/mina-loader/test/fixtures/entry/app-not-existed-file.mina
+++ b/packages/mina-loader/test/fixtures/entry/app-not-existed-file.mina
@@ -1,0 +1,12 @@
+<config>
+{
+  "pages": [
+    "page-a.mina",
+    "page-not-existed.mina",
+  ]
+}
+</config>
+
+<script>
+App({})
+</script>

--- a/packages/mina-loader/test/mina-entry-plugin.js
+++ b/packages/mina-loader/test/mina-entry-plugin.js
@@ -324,3 +324,22 @@ test('pages / usingComponents could be unknown file type with MinaEntryPlugin', 
 
   t.pass()
 })
+
+test('do not crash with MinaEntryPlugin when some pathes in pages / usingComponents are not existed', async t => {
+  const { compile, mfs } = compiler({
+    context: resolveRelative('fixtures/entry'),
+    entry: './app-not-existed-file.mina',
+    output: {
+      filename: '[name]',
+    },
+    plugins: [new MinaEntryPlugin()],
+  })
+  const stats = await compile()
+
+  t.true(stats.compilation.errors.length > 0)
+
+  t.true(mfs.existsSync('/app-not-existed-file.js'))
+  t.true(mfs.existsSync('/page-a.js'))
+  t.true(mfs.existsSync('/page-a.wxml'))
+  t.pass()
+})


### PR DESCRIPTION
在mina文件的config模块中，如果引入的组件路径有误，则`npm start`就直接异常退出了。这对于开发来说不太友好，例如我就会时不时地修改组件的名字和位置。

这个pullrequest做了以下的事情：

**首先，config中的引用错误不会终止webpack，而是打印如下的字段**

```
ERROR in Entry module not found: Error: Can't resolve './components/none' in '/home/hello/workspace/run27017/mina-webpack-testing/simple-app/src'

ERROR in Entry module not found: Error: Can't resolve './pages/none' in '/home/hello/workspace/run27017/mina-webpack-testing/simple-app/src'
```

可以看出，每个引入异常用一行来显示（红字显示），之前的长长的异常栈并不能给我们更多的有效信息。

**然后，mina-loader不要抛出异常，而是保留原始的写法。这个时候，组件引入的错误交给微信开发工具来探测。**

例如以下的config，经过mina-loader处理之后会变成：

```json
// 原始写法
{
  "usingComponents": {
    "author": "/components/author",
    "none": "/components/none"
  }
}

// mina-loader处理后
{
  "usingComponents": {
    "author": "../components/author",
    "none": "/components/none"
  }
}
```

大意是，author组件正常被处理为`../components/author`，none组件保留原始写法。

做出这样的决定，是因为mina-loader抛出的异常，会将同样的错误抛出两次。