### PR TITLE
mina-loader: 为lang属性增加前置、主要、后置三个loader配置项

### DIFF
--- a/packages/mina-loader/lib/loaders/mina.js
+++ b/packages/mina-loader/lib/loaders/mina.js
@@ -36,9 +36,22 @@ const getLoaders = (loaderContext, tag, options, attributes = {}) => {
     return ''
   }
 
-  // append custom loader
-  let custom = lang
-    ? options.languages[lang] || `${lang}-loader`
+  const getCustomizedLoader = (lang, { loaders = {}, languages = {} }) => {
+    const beforeLoader = languages[`${lang}:before`]
+    const mainLoader =  languages[`${lang}:main`] || loaders[tag]
+    const afterLoader = languages[`${lang}:after`] || languages[lang]
+    const toArray = val => {
+      if (val === undefined || val === null || val === '') {
+        return []
+      }
+      return Array.isArray(val) ? val : [val]
+    }
+    return [...toArray(beforeLoader), ...toArray(mainLoader), ...toArray(afterLoader)]
+  }
+
+  // HACK: 一旦getLoaders函数内发生异常，测试代码没有显示任何异常，应该是在某个地方压制住了它。望改善！
+  let custom = lang 
+    ? (Object.keys(options.languages).length === 0 ? `${lang}-loader` : getCustomizedLoader(lang, options))
     : options.loaders[tag] || ''
   if (custom) {
     custom = helpers.stringifyLoaders(

--- a/packages/mina-loader/package-lock.json
+++ b/packages/mina-loader/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinajs/mina-loader",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -209,6 +209,45 @@
       "dev": true,
       "requires": {
         "any-observable": "^0.3.0"
+      }
+    },
+    "@tinajs/mina-entry-webpack-plugin": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/@tinajs/mina-entry-webpack-plugin/download/@tinajs/mina-entry-webpack-plugin-1.0.2.tgz",
+      "integrity": "sha1-6/hzSiet+ZSCua530nCGJju2R5A=",
+      "dev": true,
+      "requires": {
+        "compose-function": "^3.0.3",
+        "ensure-posix-path": "^1.0.2",
+        "flatten": "^1.0.2",
+        "fs-extra": "^4.0.2",
+        "json5": "^0.5.1",
+        "loader-utils": "^1.1.0",
+        "minimatch": "^3.0.4",
+        "p-props": "^1.2.0",
+        "replace-ext": "^1.0.0",
+        "resolve": "^1.8.1",
+        "resolve-from": "^4.0.0",
+        "vue-template-compiler": "^2.5.3"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "http://registry.npm.taobao.org/resolve-from/download/resolve-from-4.0.0.tgz",
+          "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
+          "dev": true
+        }
+      }
+    },
+    "@tinajs/mina-runtime-webpack-plugin": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/@tinajs/mina-runtime-webpack-plugin/download/@tinajs/mina-runtime-webpack-plugin-1.0.1.tgz",
+      "integrity": "sha1-ig4NgkPbp3GYxg/jNJVPjMsrS8M=",
+      "dev": true,
+      "requires": {
+        "debug": "^3.1.0",
+        "ensure-posix-path": "^1.0.2",
+        "webpack-sources": "^1.0.2"
       }
     },
     "@tinajs/mina-sfc": {
@@ -3565,6 +3604,17 @@
         "js-yaml": "^3.10.0"
       }
     },
+    "fs-extra": {
+      "version": "4.0.3",
+      "resolved": "http://registry.npm.taobao.org/fs-extra/download/fs-extra-4.0.3.tgz",
+      "integrity": "sha1-DYUhIuW8W+tFP7Ao6cDJvzY0DJQ=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
       "resolved": "http://registry.npm.taobao.org/fs-write-stream-atomic/download/fs-write-stream-atomic-1.0.10.tgz",
@@ -5081,6 +5131,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "http://registry.npm.taobao.org/jsonfile/download/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -6904,6 +6963,15 @@
       "version": "1.2.0",
       "resolved": "http://registry.npm.taobao.org/p-map/download/p-map-1.2.0.tgz",
       "integrity": "sha1-5OlPMR6rvIYzoeeZCBZfyiYkG2s="
+    },
+    "p-props": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/p-props/download/p-props-1.2.0.tgz",
+      "integrity": "sha1-2cvdMq4gtiNKY6HSDEHyccM+Fmk=",
+      "dev": true,
+      "requires": {
+        "p-map": "^1.2.0"
+      }
     },
     "package-hash": {
       "version": "2.0.0",
@@ -11645,6 +11713,12 @@
         "os-tmpdir": "^1.0.1",
         "uid2": "0.0.3"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "http://registry.npm.taobao.org/universalify/download/universalify-0.1.2.tgz",
+      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",

--- a/packages/mina-loader/test/fixtures/lang/override-loader.mina
+++ b/packages/mina-loader/test/fixtures/lang/override-loader.mina
@@ -1,7 +1,7 @@
-<script lang="yellowify">
+<script lang="number">
 Page({
   onLoad () {
-    console.log('blue');
+    console.log(9);
   }
 })
 </script>

--- a/packages/mina-loader/test/helpers/loaders/number-add-one-loader.js
+++ b/packages/mina-loader/test/helpers/loaders/number-add-one-loader.js
@@ -1,0 +1,7 @@
+/**
+ * 找出其中的所有数字，每个加上1.
+ */
+
+module.exports = function(source) {
+  return source.replace(/\d+/g, val => Number(val) + 1)
+}

--- a/packages/mina-loader/test/helpers/loaders/number-multiply-two-loader.js
+++ b/packages/mina-loader/test/helpers/loaders/number-multiply-two-loader.js
@@ -1,0 +1,7 @@
+/**
+ * 找出其中的所有数字，每个乘以2.
+ */
+
+module.exports = function(source) {
+  return source.replace(/\d+/g, val => Number(val) * 2)
+}

--- a/packages/mina-loader/test/lang.js
+++ b/packages/mina-loader/test/lang.js
@@ -68,7 +68,7 @@ test('use lang attribute with extra rules', async t => {
   }
 })
 
-test('use lang attribute should override loaders options', async t => {
+test('use lang before attribute should prepend loaders options', async t => {
   try {
     const { compile, mfs } = compiler({
       entry: './fixtures/lang/override-loader.mina',
@@ -83,10 +83,10 @@ test('use lang attribute should override loaders options', async t => {
               loader: require.resolve('..'),
               options: {
                 loaders: {
-                  script: 'babel-loader',
+                  script: './helpers/loaders/number-multiply-two-loader.js',
                 },
                 languages: {
-                  yellowify: './helpers/loaders/replace-blue-to-yellow',
+                  'number:before': './helpers/loaders/number-add-one-loader.js', // (9*2)+1
                 },
               },
             },
@@ -94,31 +94,94 @@ test('use lang attribute should override loaders options', async t => {
         ],
       },
     })
-    const stats = await compile()
+    await compile()
 
     t.true(
       mfs
         .readFileSync('/fixtures/lang/override-loader.js', 'utf8')
-        .includes("console.log('yellow')")
+        .includes("console.log(19)")
     )
-    t.false(
-      mfs
-        .readFileSync('/fixtures/lang/override-loader.js', 'utf8')
-        .includes("console.log('blue')")
-    )
+  } catch (error) {
+    console.error(error)
+  }
+})
+
+test('use lang after attribute should append loaders options', async t => {
+  try {
+    const { compile, mfs } = compiler({
+      entry: './fixtures/lang/override-loader.mina',
+      output: {
+        filename: 'fixtures/lang/override-loader.js',
+      },
+      module: {
+        rules: [
+          {
+            test: /\.mina$/,
+            use: {
+              loader: require.resolve('..'),
+              options: {
+                loaders: {
+                  script: './helpers/loaders/number-multiply-two-loader.js',
+                },
+                languages: {
+                  'number:after': './helpers/loaders/number-add-one-loader.js', // (9+1)*2
+                },
+              },
+            },
+          },
+        ],
+      },
+    })
+    await compile()
 
     t.true(
       mfs
         .readFileSync('/fixtures/lang/override-loader.js', 'utf8')
-        .includes('onLoad () {')
+        .includes("console.log(20)")
+    )
+  } catch (error) {
+    console.error(error)
+  }
+})
+
+test('use lang main attribute should override loaders options', async t => {
+  try {
+    const { compile, mfs } = compiler({
+      entry: './fixtures/lang/override-loader.mina',
+      output: {
+        filename: 'fixtures/lang/override-loader.js',
+      },
+      module: {
+        rules: [
+          {
+            test: /\.mina$/,
+            use: {
+              loader: require.resolve('..'),
+              options: {
+                loaders: {
+                  script: './helpers/loaders/number-multiply-two-loader.js',
+                },
+                languages: {
+                  'number:main': './helpers/loaders/number-add-one-loader.js', // 9+1
+                },
+              },
+            },
+          },
+        ],
+      },
+    })
+    await compile()
+
+    t.true(
+      mfs
+        .readFileSync('/fixtures/lang/override-loader.js', 'utf8')
+        .includes("console.log(10)")
     )
     t.false(
       mfs
         .readFileSync('/fixtures/lang/override-loader.js', 'utf8')
-        .includes('onLoad: function onLoad() {')
+        .includes("console.log(18)")
     )
-
-    t.pass()
   } catch (error) {
     console.error(error)
   }


### PR DESCRIPTION
mina-loader的lang属性会完全覆盖对应tag下的loader配置，这会让明显的配置显得过于冗长，例如我想加入less-loader给`lang=less`，不得不这样写：

```js
{
  loaders: {
    script: 'babel-loader',
    style: {
      loader: 'postcss-loader',
      options: {
        config: {
          path: resolve('./postcss.config.js')
        }
      }
    }
  },
  languages: {
    scss: [
      {
        loader: 'postcss-loader',
        options: {
          config: {
            path: resolve('./postcss.config.js')
          }
        }
      },
      'sass-loader'
    ]
  }
}
```

可以看出，关于postcss-loader的配置写了两遍。

我的想法是，给lang加入个后缀`after`、`before`、`cover`，以给原始的postcss-loader prepend or append or override 其他的loaders。

```js
languages: {
  "scss:after": "sass-loader", // 等价于[postcss-loader, sass-loader]
  "scss:before": "sass-loader", // 等价于[sass-loader, postcss-loader]
  "scss:after": "sass-loader", // 等价于[sass-loader]，postcss-loader被替换了
  "scss": "sass-loader" // 考虑到最常用的情况，等价于sass:after
}
```