### PR TITLE
[Mina-loader] Fix subpackage issue #118

### DIFF
--- a/packages/mina-loader/package-lock.json
+++ b/packages/mina-loader/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinajs/mina-loader",
-  "version": "1.6.0",
+  "version": "1.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/mina-loader/src/loaders/mina-json.ts
+++ b/packages/mina-loader/src/loaders/mina-json.ts
@@ -52,6 +52,13 @@ function resolveFile(
   if (subpackageMapping[transformedTarget]) {
     transformedTarget = subpackageMapping[transformedTarget]
   }
+  // when we moved an mina to a subpackage in during mina-webpack-plugin, this.resourcePath context is
+  // not updated, this would cause resolving target end up getting incorrect calculated path in `.json`.
+  // it’s complicated to update this.resourcePath in the plugin as it’s handled by webpack, so compensate
+  // the change here in the loader.
+  if (subpackageMapping[transformedSource]) {
+    transformedSource = subpackageMapping[transformedSource]
+  }
 
   debug('resolve file in mina-json', {
     source,

--- a/packages/mina-loader/test/fixtures/subpackages/src/app.mina
+++ b/packages/mina-loader/test/fixtures/subpackages/src/app.mina
@@ -1,0 +1,28 @@
+<config>
+{
+  "pages": [
+    "pages/home.mina"
+  ],
+	"subPackages": [
+		{
+      "name": "sub1",
+      "root": "sub1",
+      "pages": [
+        "page1.mina",
+        "page2.mina",
+      ]
+    },
+    {
+      "name": "sub2",
+      "root": "sub2",
+      "pages": [
+        "page1.mina",
+      ]
+    },
+	]
+}
+</config>
+
+<script>
+App({})
+</script>

--- a/packages/mina-loader/test/fixtures/subpackages/src/components/a.mina
+++ b/packages/mina-loader/test/fixtures/subpackages/src/components/a.mina
@@ -1,0 +1,16 @@
+<config>
+{
+  "usingComponents": {
+    "c": "c.mina",
+    "d": "d.mina",
+  }
+}
+</config>
+
+<template>
+  <view>
+    <view>a component</view>
+    <c />
+    <d />
+  </view>
+</template>

--- a/packages/mina-loader/test/fixtures/subpackages/src/components/b.mina
+++ b/packages/mina-loader/test/fixtures/subpackages/src/components/b.mina
@@ -1,0 +1,14 @@
+<config>
+{
+  "usingComponents": {
+    "d": "d.mina",
+  }
+}
+</config>
+
+<template>
+  <view>
+    <view>b component</view>
+    <d />
+  </view>
+</template>

--- a/packages/mina-loader/test/fixtures/subpackages/src/components/c.mina
+++ b/packages/mina-loader/test/fixtures/subpackages/src/components/c.mina
@@ -1,0 +1,9 @@
+<config>
+{
+  component: true,
+}
+</config>
+
+<template>
+  <view>a component</view>
+</template>

--- a/packages/mina-loader/test/fixtures/subpackages/src/components/d.mina
+++ b/packages/mina-loader/test/fixtures/subpackages/src/components/d.mina
@@ -1,0 +1,9 @@
+<config>
+{
+  component: true,
+}
+</config>
+
+<template>
+  <view>a component</view>
+</template>

--- a/packages/mina-loader/test/fixtures/subpackages/src/pages/home.mina
+++ b/packages/mina-loader/test/fixtures/subpackages/src/pages/home.mina
@@ -1,0 +1,17 @@
+<config>
+{
+  "usingComponents": {
+    "logo": "~logo.mina",
+  }
+}
+</config>
+
+<template>
+  <view>
+    <logo />
+  </view>
+</template>
+
+<script>
+Page({})
+</script>

--- a/packages/mina-loader/test/fixtures/subpackages/src/sub1/page1.mina
+++ b/packages/mina-loader/test/fixtures/subpackages/src/sub1/page1.mina
@@ -1,0 +1,19 @@
+<config>
+{
+  "usingComponents": {
+    "a": "/components/a.mina",
+    "b": "/components/b.mina",
+  }
+}
+</config>
+
+<template>
+  <view>
+    <a />
+    <b />
+  </view>
+</template>
+
+<script>
+Page({})
+</script>

--- a/packages/mina-loader/test/fixtures/subpackages/src/sub1/page2.mina
+++ b/packages/mina-loader/test/fixtures/subpackages/src/sub1/page2.mina
@@ -1,0 +1,17 @@
+<config>
+{
+  "usingComponents": {
+    "a": "/components/a.mina",
+  }
+}
+</config>
+
+<template>
+  <view>
+    <a />
+  </view>
+</template>
+
+<script>
+Page({})
+</script>

--- a/packages/mina-loader/test/fixtures/subpackages/src/sub2/page1.mina
+++ b/packages/mina-loader/test/fixtures/subpackages/src/sub2/page1.mina
@@ -1,0 +1,17 @@
+<config>
+{
+  "usingComponents": {
+    "b": "/components/b.mina",
+  }
+}
+</config>
+
+<template>
+  <view>
+    <b />
+  </view>
+</template>
+
+<script>
+Page({})
+</script>

--- a/packages/mina-loader/test/subpackages.js
+++ b/packages/mina-loader/test/subpackages.js
@@ -1,0 +1,61 @@
+import path from 'path'
+import test from 'ava'
+import MinaEntryPlugin from '@tinajs/mina-entry-webpack-plugin'
+import compiler from './helpers/compiler'
+
+const resolveRelative = path.resolve.bind(null, __dirname)
+
+test('subpackages', async t => {
+  const { compile, mfs } = compiler({
+    context: resolveRelative('fixtures/subpackages/src'),
+    entry: 'app.mina',
+    output: {
+      filename: 'app.js',
+    },
+    plugins: [new MinaEntryPlugin()],
+  })
+
+  await compile()
+  // sub1
+  t.deepEqual(JSON.parse(mfs.readFileSync('/sub1/page1.json', 'utf-8')), {
+    usingComponents: {
+      a: './_/components/a', // a is moved to sub1
+      b: './../components/b', // b is shared from sub1, sub2, so it's not moved
+    },
+  })
+  // sub2
+  t.deepEqual(JSON.parse(mfs.readFileSync('/sub2/page1.json', 'utf-8')), {
+    usingComponents: {
+      b: './../components/b', // b is shared from sub1, sub2, so it's not moved
+    },
+  })
+  // a is only used by sub1, it is moved
+  t.deepEqual(
+    JSON.parse(mfs.readFileSync('/sub1/_/components/a.json', 'utf-8')),
+    {
+      usingComponents: {
+        c: './c', // c is also moved
+        d: './../../../components/d', // d is not moved
+      },
+    }
+  )
+  // b is shared by sub1 and sub2, it is not moved
+  t.deepEqual(JSON.parse(mfs.readFileSync('/components/b.json', 'utf-8')), {
+    usingComponents: {
+      d: './d', // d is not moved
+    },
+  })
+  // c is only used by a, it is moved
+  t.deepEqual(
+    JSON.parse(mfs.readFileSync('/sub1/_/components/c.json', 'utf-8')),
+    {
+      component: true,
+    }
+  )
+  // d is shared by a and b, it's not moved
+  t.deepEqual(JSON.parse(mfs.readFileSync('/components/d.json', 'utf-8')), {
+    component: true,
+  })
+
+  t.pass()
+})


### PR DESCRIPTION
**Issue**
https://github.com/tinajs/mina-webpack/issues/118 from https://github.com/tinajs/mina-webpack/pull/111

**Root Cause**
When we moved an mina to a subpackage in during mina-webpack-plugin, `this.resourcePath` context is no updated. So resolving `target` from `source` can end up wrong. 

Alternatively we can fix this from `mina-entry-webpack-plugin`, but `this.resourcePath` is provided by webpack and it is difficult to update cleanly. This fix is cleaner.

**Test**
I made this fix in my node_modules and it fixed the issue.

P.S. I was trying to add a unit test, but running `npm test` always fails complaining either `@tinajs/mina-entry-webpack-plugin` or `@tinajs/mina-loader` not found