### PR TITLE
support baidu dynamicLib

### DIFF
--- a/packages/mina-entry-webpack-plugin/src/index.ts
+++ b/packages/mina-entry-webpack-plugin/src/index.ts
@@ -46,6 +46,8 @@ const DEFAULT_EXTENSIONS: Extensions = {
   resolve: ['.js', '.wxml', '.json', '.wxss'],
 }
 
+const pluginPrefixReg = /^(plugin|dynamicLib):\/\//;
+
 function isAbsoluteUrl(url: string) {
   return !!url.startsWith('/')
 }
@@ -260,7 +262,7 @@ function getEntries(
     }
     if (requests.length > 0) {
       requests.forEach(req => {
-        if (req.startsWith('plugin://')) {
+        if (pluginPrefixReg.test(req)) {
           return
         }
         return search(path.dirname(realPath), req, entry)

--- a/packages/mina-loader/src/loaders/mina-json.ts
+++ b/packages/mina-loader/src/loaders/mina-json.ts
@@ -17,6 +17,8 @@ import * as helpers from '../helpers'
 import { RESOLVABLE_EXTENSIONS } from '../constants'
 import webpack from 'webpack'
 
+const pluginPrefixReg = /^(plugin|dynamicLib):\/\//;
+
 function stripExt(path: string): string {
   return replaceExt(path, '')
 }
@@ -240,7 +242,7 @@ const minaJson: webpack.loader.Loader = function minaJson(source) {
 
       return Object.assign(config, {
         usingComponents: mapValues(config.usingComponents, (file: string) => {
-          if (file.startsWith('plugin://')) {
+          if (pluginPrefixReg.test(file)) {
             return file
           }
 

--- a/packages/mina-loader/test/fixtures/resolve-components/src/pages/home.mina
+++ b/packages/mina-loader/test/fixtures/resolve-components/src/pages/home.mina
@@ -7,7 +7,8 @@
     "d": "./d.mina",
     "logo": "~logo.mina",
     "tab": "~tab",
-    "plugin": "plugin://foobar/component"
+    "plugin": "plugin://foobar/component",
+    "dynamicLib": "dynamicLib://swan-sitemap-lib/component"
   }
 }
 </config>

--- a/packages/mina-loader/test/resolve-components.js
+++ b/packages/mina-loader/test/resolve-components.js
@@ -26,6 +26,7 @@ test('resolve components', async t => {
       logo: './../_/_node_modules_/logo.mina/dist/logo',
       tab: './../_/_node_modules_/tab/tab',
       plugin: 'plugin://foobar/component',
+      dynamicLib: 'dynamicLib://swan-sitemap-lib/component',
     },
   })
 


### PR DESCRIPTION
This pr tries to support the usage of dynamiclib in baidu mini program, which is similar to wechat plugin. It involves changes in entry and usingComponents.

reference: https://smartprogram.baidu.com/docs/develop/framework/dynamiclib_use/  